### PR TITLE
[RSDK-5633]   Fix stereo depth component not setting output size correctly

### DIFF
--- a/src/worker.py
+++ b/src/worker.py
@@ -314,12 +314,15 @@ class Worker:
 
         # Filter for only dimensions that are larger or equal to the required width and height
         valid_dimensions = {
-            dim: res for dim, res in dimensions_to_resolution.items()
+            dim: res
+            for dim, res in dimensions_to_resolution.items()
             if dim[0] >= self.width and dim[1] >= self.height
         }
 
         if not valid_dimensions:
-            raise ValueError("No valid resolutions found that are larger or equal to the required dimensions.")
+            raise ValueError(
+                "No valid resolutions found that are larger or equal to the required dimensions."
+            )
 
         closest = min(
             valid_dimensions.keys(),


### PR DESCRIPTION
Context on Jira: [RSDK-5633](https://viam.atlassian.net/browse/RSDK-5633)

Sent out [a related PR in the DepthAI SDK](https://github.com/luxonis/depthai/pull/1187) that implements the actual logic on their side (blocked from merging bc of this)

[RSDK-5633]: https://viam.atlassian.net/browse/RSDK-5633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

The changes in this current PR in our module is also necessary because we don't just want the closest resolution. We want the closest resolution that is larger than the given dimensions (so that cropping works properly).