### PR TITLE
[RSDK-6312]   Change OAK module method return types to ViamImage

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,7 @@
 depthai-sdk==1.13.1
 viam-sdk==0.25.2
+Pillow==10.4.0
+numpy>=1.23,<2.0.0  # >2.0.0 breaks depthai https://github.com/luxonis/depthai-viewer/releases/tag/v0.2.3
 google-api-python-client==2.0.0
 pytest
 black

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 depthai-sdk==1.13.1
-viam-sdk==0.11.0
+viam-sdk==0.25.2
 google-api-python-client==2.0.0
 pytest
 black

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 depthai-sdk==1.13.1
 viam-sdk==0.25.2
+Pillow==10.4.0
+numpy>=1.23,<2.0.0  # >2.0.0 breaks depthai https://github.com/luxonis/depthai-viewer/releases/tag/v0.2.3
 google-api-python-client==2.0.0
 pyinstaller==6.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 depthai-sdk==1.13.1
-viam-sdk==0.11.0
+viam-sdk==0.25.2
 google-api-python-client==2.0.0
 pyinstaller==6.3.0

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -152,7 +152,7 @@ def encode_jpeg_bytes(arr: NDArray, is_depth: bool = False) -> bytes:
         if arr.dtype != np.uint8:
             raise ValueError("RGB data should be of type uint8")
         pil_image = Image.fromarray(arr)
-    
+
     with io.BytesIO() as output_buffer:
         pil_image.save(output_buffer, format="JPEG")
         raw_bytes = output_buffer.getvalue()

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -1,0 +1,158 @@
+from collections import OrderedDict
+import io
+from logging import Logger
+from threading import Lock
+import struct
+import time
+from typing import (
+    Dict,
+    Literal,
+    Optional,
+    OrderedDict,
+    Tuple
+)
+from depthai_sdk.classes.packets import BasePacket
+from depthai_sdk.classes.packet_handlers import QueuePacketHandler
+from numpy.typing import NDArray
+import numpy as np
+from PIL import Image
+
+
+class MessageSynchronizer:
+    """
+    MessageSynchronizer manages synchronization of frame messages for color and depth data from OakCamera packet queues,
+    maintaining an ordered dictionary of messages keyed chronologically by sequence number.
+    """
+
+    MAX_MSGS_SIZE = 50
+    msgs: OrderedDict[int, Dict[str, BasePacket]]
+    write_lock: Lock
+
+    def __init__(self):
+        # msgs maps frame sequence number to a dictionary that maps frame_type (i.e. "color" or "depth") to a data packet
+        self.msgs = OrderedDict()
+        self.write_lock = Lock()
+
+    def add_msg(
+        self, msg: BasePacket, frame_type: Literal["color", "depth"], seq: int
+    ) -> None:
+        with self.write_lock:
+            # Update recency if previously already stored in dict
+            if seq in self.msgs:
+                self.msgs.move_to_end(seq)
+
+            self.msgs.setdefault(seq, {})[frame_type] = msg
+            self._cleanup_msgs()
+
+    def get_synced_msgs(self) -> Optional[Dict[str, BasePacket]]:
+        for sync_msgs in self.msgs.values():
+            if len(sync_msgs) == 2:  # has both color and depth
+                return sync_msgs
+        return None
+
+    def _add_msgs_from_queue(
+        self, frame_type: Literal["color", "depth"], queue_handler: QueuePacketHandler
+    ) -> None:
+        queue_obj = queue_handler.get_queue()
+        with queue_obj.mutex:
+            q_snapshot = list(queue_obj.queue)
+
+        for msg in q_snapshot:
+            self.add_msg(msg, frame_type, msg.get_sequence_num())
+
+    def get_most_recent_msg(
+        self, q_handler: QueuePacketHandler, frame_type: Literal["color", "depth"]
+    ) -> Optional[BasePacket]:
+        self._add_msgs_from_queue(frame_type, q_handler)
+        while len(self.msgs) < 1:
+            self._add_msgs_from_queue(frame_type, q_handler)
+            time.sleep(0.1)
+        # Traverse in reverse to get the most recent
+        for msg_dict in reversed(self.msgs.values()):
+            if frame_type in msg_dict:
+                return msg_dict[frame_type]
+        raise Exception(f"No message of type '{frame_type}' in frame queue.")
+
+    def _cleanup_msgs(self):
+        while len(self.msgs) > self.MAX_MSGS_SIZE:
+            self.msgs.popitem(last=False)  # remove oldest item
+
+
+class CapturedData:
+    """
+    CapturedData is image data with the data as an np array,
+    plus the timestamp it was captured at.
+    """
+
+    def __init__(self, np_array: NDArray, captured_at: float) -> None:
+        self.np_array = np_array
+        self.captured_at = captured_at
+
+def encode_depth_raw(data: bytes, shape: Tuple[int, int], logger: Logger) -> bytes:
+    """
+    Encodes raw data into a bytes payload deserializable by the Viam SDK (camera mime type depth)
+
+    Args:
+        data (bytes): raw bytes
+        shape (Tuple[int, int]): output dimensions of depth map (height x width)
+
+    Returns:
+        bytes: encoded bytes
+    """
+    height, width = shape  # using np shape for actual output's height/width
+    MAGIC_NUMBER = struct.pack(
+        ">Q", 4919426490892632400
+    )  # UTF-8 encoding for 'DEPTHMAP'
+    MAGIC_BYTE_COUNT = struct.calcsize("Q")
+    WIDTH_BYTE_COUNT = struct.calcsize("Q")
+    HEIGHT_BYTE_COUNT = struct.calcsize("Q")
+
+    # Depth header contains 8 bytes for the magic number, followed by 8 bytes for width and 8 bytes for height. Each pixel has 2 bytes.
+    pixel_byte_count = np.dtype(np.uint16).itemsize * width * height
+    width_to_encode = struct.pack(">Q", width)  # Q signifies big-endian
+    height_to_encode = struct.pack(">Q", height)
+    total_byte_count = (
+        MAGIC_BYTE_COUNT + WIDTH_BYTE_COUNT + HEIGHT_BYTE_COUNT + pixel_byte_count
+    )
+    logger.debug(
+        f"Calculated size:  {MAGIC_BYTE_COUNT} + {WIDTH_BYTE_COUNT} + {HEIGHT_BYTE_COUNT} + {pixel_byte_count} = {total_byte_count}"
+    )
+    logger.debug(f"Actual data size: {len(data)}")
+
+    # Create a bytearray to store the encoded data
+    raw_buf = bytearray(total_byte_count)
+    offset = 0
+
+    # Copy the depth magic number into the buffer
+    raw_buf[offset : offset + MAGIC_BYTE_COUNT] = MAGIC_NUMBER
+    offset += MAGIC_BYTE_COUNT
+
+    # Copy the encoded width and height into the buffer
+    raw_buf[offset : offset + WIDTH_BYTE_COUNT] = width_to_encode
+    offset += WIDTH_BYTE_COUNT
+    raw_buf[offset : offset + HEIGHT_BYTE_COUNT] = height_to_encode
+    offset += HEIGHT_BYTE_COUNT
+
+    # Copy data into rest of the buffer
+    raw_buf[offset : offset + pixel_byte_count] = data
+    return bytes(raw_buf)
+
+def encode_jpeg_bytes(arr: NDArray, is_depth: bool = False) -> bytes:
+    """
+    Encodes numpy color image data into a bytes decodable in the JPEG image format.
+
+    Args:
+        arr (NDArray): frame
+        is_depth (bool): whether arr is depth data or RGB data
+
+    Returns:
+        bytes: JPEG bytes
+    """
+    if is_depth:
+        pil_image = Image.fromarray(arr, "I;16").convert("RGB")
+    else:
+        pil_image = Image.fromarray(arr)
+    output_buffer = io.BytesIO()
+    pil_image.save(output_buffer, format="JPEG")
+    raw_bytes = output_buffer.getvalue()
+    return raw_bytes

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -135,7 +135,7 @@ def encode_depth_raw(data: bytes, shape: Tuple[int, int], logger: Logger) -> byt
 
 def encode_jpeg_bytes(arr: NDArray, is_depth: bool = False) -> bytes:
     """
-    Encodes numpy color image data into a bytes decodable in the JPEG image format.
+    Encodes numpy color image data into bytes decodable in the JPEG image format.
 
     Args:
         arr (NDArray): frame
@@ -145,10 +145,15 @@ def encode_jpeg_bytes(arr: NDArray, is_depth: bool = False) -> bytes:
         bytes: JPEG bytes
     """
     if is_depth:
-        pil_image = Image.fromarray(arr, "I;16").convert("RGB")
+        if arr.dtype != np.uint16:
+            raise ValueError("Depth data should be of type uint16")
+        pil_image = Image.fromarray(arr, mode="I;16").convert("RGB")
     else:
+        if arr.dtype != np.uint8:
+            raise ValueError("RGB data should be of type uint8")
         pil_image = Image.fromarray(arr)
-    output_buffer = io.BytesIO()
-    pil_image.save(output_buffer, format="JPEG")
-    raw_bytes = output_buffer.getvalue()
+    
+    with io.BytesIO() as output_buffer:
+        pil_image.save(output_buffer, format="JPEG")
+        raw_bytes = output_buffer.getvalue()
     return raw_bytes

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -4,13 +4,7 @@ from logging import Logger
 from threading import Lock
 import struct
 import time
-from typing import (
-    Dict,
-    Literal,
-    Optional,
-    OrderedDict,
-    Tuple
-)
+from typing import Dict, Literal, Optional, OrderedDict, Tuple
 from depthai_sdk.classes.packets import BasePacket
 from depthai_sdk.classes.packet_handlers import QueuePacketHandler
 from numpy.typing import NDArray
@@ -88,6 +82,7 @@ class CapturedData:
         self.np_array = np_array
         self.captured_at = captured_at
 
+
 def encode_depth_raw(data: bytes, shape: Tuple[int, int], logger: Logger) -> bytes:
     """
     Encodes raw data into a bytes payload deserializable by the Viam SDK (camera mime type depth)
@@ -136,6 +131,7 @@ def encode_depth_raw(data: bytes, shape: Tuple[int, int], logger: Logger) -> byt
     # Copy data into rest of the buffer
     raw_buf[offset : offset + pixel_byte_count] = data
     return bytes(raw_buf)
+
 
 def encode_jpeg_bytes(arr: NDArray, is_depth: bool = False) -> bytes:
     """

--- a/src/oak.py
+++ b/src/oak.py
@@ -363,7 +363,7 @@ class Oak(Camera, Reconfigurable, Stoppable):
                 arr = cls.worker.get_color_image().np_array
                 jpeg_encoded_bytes = encode_jpeg_bytes(arr)
                 return ViamImage(jpeg_encoded_bytes, CameraMimeType.JPEG)
-                
+
             raise NotSupportedError(
                 f'mime_type "{mime_type}" is not supported for color. Please use {CameraMimeType.JPEG}'
             )


### PR DESCRIPTION
[RSDK-6312](https://viam.atlassian.net/browse/RSDK-6312)

Update our module's Viam Python SDK dependency to consume ViamImage. Refactors and code cleanup added as appropriate

Changes
- Created `helpers.py` to take care of shared classes and image transcoding helpers
- Moved encode depth raw func from OAK method to `helpers.py` as a standalone func
- Added encode jpeg bytes as shared logic rather than spaghetti
- Changed `get_image` signature to return ViamImage
- Updated requirements deps list to account for numpy breaking change and Viam SDK changes

[RSDK-6312]: https://viam.atlassian.net/browse/RSDK-6312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Testing
### Color only (get_image)
```
{
  "sensors": [
    "color"
  ]
}
``` 
Color stream looks good on app

### Depth only (get_image)
```
{
  "sensors": [
    "depth"
  ]
}
```
Depth stream looks good on app

### Color and depth (get_images)
```
{
  "sensors": [
    "color",
    "depth"
  ]
}
```
Tested with my python-sdk client:
```
async def connect():
    opts = RobotClient.Options.with_api_key(
      api_key='<secret>',
      api_key_id='<secret-id>'
    )
    address = '<addy>'

    return await RobotClient.at_address(address, opts)

async def get_images(cam: Camera):
    images = await cam.get_images()
    assert len(images) == 2 
    assert len(images[0]) == 2
    color_img, depth_map = images[0][0], images[0][1]
    metadata = images[1]
    print(f"captured at: {metadata.captured_at}")
    check_jpeg_image_from_get_images(color_img)
    check_depth_map_from_get_images(depth_map)
   

def check_jpeg_image_from_get_images(named_image: NamedImage):
    image = named_image.image
    if image is None:
        raise Exception("image is None")
    np_array = np.array(image)
    print("color image format: " + image.format)
    print("color image shape: " + str(np_array.shape))

def check_depth_map_from_get_images(depth_map: NamedImage):
    print(f'{len(depth_map.data)}')
    depth_arr = depth_map.bytes_to_depth_array()
    np_array = np.asarray(depth_arr, dtype=np.uint16)
    print("depth array shape: " + str(np_array.shape))

"""
The main function is the one called upon script execution. It sets up and calls the
two other functions.
"""
async def main():
    robot = await connect()
    cam = Camera.from_robot(robot, 'oak-cam')

    await get_images(cam)
    await cam.close()
    await robot.close()


if __name__ == '__main__':
  asyncio.run(main())
```
Outputted:
```
captured at: seconds: 165
nanos: 173421999

color image format: JPEG
color image shape: (400, 640, 3)
512024
depth array shape: (400, 640)
```
The key part is that `bytes_to_depth_array` was successful. Meaning there is no format error for the depth map with the new ViamImage under-the-hood impl