### PR TITLE
RSDK-13341: Document get_images source names

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ The `get_images` method returns named images that can be filtered using `filter_
 | `color_cam_a` | `"color"` is in the `sensors` attribute | `image/jpeg` |
 | `depth` | `"depth"` is in the `sensors` attribute | `image/vnd.viam.dep` |
 
-When both `"color"` and `"depth"` sensors are configured and both source names are requested (either via `filter_source_names: ["color_cam_a", "depth"]` or by omitting the filter entirely), `get_images` returns synchronized frames with aligned timestamps and matching dimensions. Filtering for only one source bypasses synchronization.
+When both sensors are configured and `get_images` is called without a filter (or with both source names), it returns synchronized frames with aligned timestamps and matching dimensions. Filtering for only one source bypasses synchronization.
 
 ### `oak-ffc-3p`
 

--- a/README.md
+++ b/README.md
@@ -233,6 +233,28 @@ Below is an example full configuration of a `yolo-detection-network` service:
 ```
 
 
+## `get_images` source names
+
+The `get_images` method returns named images that can be filtered using `filter_source_names`. The available source names depend on the model and its configured sensors.
+
+### `oak-d`
+
+| Source Name | Returned When | MIME Type |
+| ----------- | ------------- | --------- |
+| `color_cam_a` | `"color"` is in the `sensors` attribute | `image/jpeg` |
+| `depth` | `"depth"` is in the `sensors` attribute | `image/vnd.viam.dep` |
+
+When both `"color"` and `"depth"` sensors are configured and both source names are requested (either via `filter_source_names: ["color_cam_a", "depth"]` or by omitting the filter entirely), `get_images` returns synchronized frames with aligned timestamps and matching dimensions. Filtering for only one source bypasses synchronization.
+
+### `oak-ffc-3p`
+
+| Source Name | Returned When | MIME Type |
+| ----------- | ------------- | --------- |
+| `color_{socket}` | A color-type sensor is configured on `{socket}` | `image/jpeg` |
+| `depth` | Two depth-type sensors are configured (forming a stereo pair) | `image/vnd.viam.dep` |
+
+Source names for color sensors are derived from their socket, e.g. a color sensor on `cam_a` produces `color_cam_a`, one on `cam_c` produces `color_cam_c`. Multiple color sensors each get their own source name. There is no synchronized output path for the FFC model.
+
 ## Next steps
 
 ### View camera outputs in App

--- a/src/config.py
+++ b/src/config.py
@@ -315,12 +315,10 @@ class OakDConfig(OakConfig):
         # Check sensors is valid
         sensors_value = attribute_map.get(key="sensors", default=None)
         if sensors_value is None:
-            handle_err(
-                """
+            handle_err("""
                 a "sensors" attribute of a list of sensor(s) is a required attribute e.g. ["depth", "color"],
                 with the first sensor in the list being the main sensor that get_image uses.
-                """
-            )
+                """)
         validate_attr_type("sensors", "list_value", attribute_map)
         sensor_list = list(sensors_value.list_value)
         if len(sensor_list) == 0:
@@ -329,12 +327,10 @@ class OakDConfig(OakConfig):
             handle_err('"sensors" attribute list exceeds max length of two.')
         for sensor in sensor_list:
             if sensor != "color" and sensor != "depth":
-                handle_err(
-                    f"""
+                handle_err(f"""
                             unknown sensor type "{sensor}" found in "sensors" attribute list.
                             Valid sensors include: "color" and "depth"
-                            """
-                )
+                            """)
         if len(set(sensor_list)) != len(sensor_list):
             handle_err(
                 f'please remove duplicates in the "sensors" attribute list: {sensor_list}'

--- a/src/config.py
+++ b/src/config.py
@@ -8,7 +8,6 @@ from viam.errors import ValidationError
 from viam.logging import getLogger
 from src.components.helpers.shared import get_socket_from_str
 
-
 # Be sure to update README.md if default attributes are changed
 DEFAULT_FRAME_RATE = 30
 DEFAULT_WIDTH = 1280


### PR DESCRIPTION
## Summary
- Documents the `filter_source_names` values that `get_images` returns for both `oak-d` and `oak-ffc-3p` models
- Covers source name formats, MIME types, when each source is available based on config, and the synchronized output behavior for `oak-d`

🤖 Generated with [Claude Code](https://claude.com/claude-code) and validated by me