### PR TITLE
deps: add Dependabot config to auto-bump viam-sdk

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # Open a PR to bump the Viam Python SDK whenever a new viam-sdk release is published.
+  # The pip updater bumps viam-sdk in both requirements.txt and requirements-dev.txt.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    # Only track the Viam Python SDK; ignore all other pip dependencies.
+    allow:
+      - dependency-name: "viam-sdk"
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Adds `.github/dependabot.yml` so a PR is opened automatically whenever a new [`viam-sdk`](https://pypi.org/project/viam-sdk/) release is published on PyPI.

- Scoped via `allow:` to **only** the `viam-sdk` pip dependency — no other deps are tracked.
- Polls `daily`.
- The pip updater bumps the pin in every requirements file in the repo root (here, both `requirements.txt` and `requirements-dev.txt`).

Opened as a draft for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)